### PR TITLE
Fix OpenSSL cross-compilation for ARM64 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ tokio = { version = "1.46.1", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "native-tls"], default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
 oauth2 = "4.4"
 jsonwebtoken = "9.3"
 base64 = "0.22"


### PR DESCRIPTION
## Summary
- Add vendored OpenSSL feature to resolve cross-compilation issues in GitHub Actions
- Fixes aarch64-unknown-linux-gnu target build failures
- Enables proper ARM64 binary releases for Raspberry Pi deployment

## Problem
The GitHub Actions build was failing for ARM64 targets due to missing OpenSSL development libraries during cross-compilation:
```
Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge.
```

## Solution
- Add vendored OpenSSL feature to bundle OpenSSL source code with the binary
- Configure reqwest to use native-tls with vendored OpenSSL
- This eliminates external OpenSSL dependency during cross-compilation

## Test Plan
- [x] Local compilation test passes
- [ ] GitHub Actions ARM64 build succeeds
- [ ] ARM64 binary deploys successfully to Raspberry Pi nodes
- [ ] Authentication functionality works with vendored OpenSSL

🤖 Generated with [Claude Code](https://claude.ai/code)