### PR TITLE
Fix OAuth client authentication method mismatch

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -289,8 +289,10 @@ impl AuthService {
         .set_redirect_uri(
             RedirectUrl::new(self.config.redirect_uri.clone())
                 .map_err(|e| AuthError::InvalidConfig(format!("Invalid redirect URI: {}", e)))?,
-        );
+        )
+        .set_auth_type(oauth2::AuthType::RequestBody); // Use client_secret_post instead of client_secret_basic
 
+        println!("🔧 AUTH: Configured OAuth client with client_secret_post authentication method");
         self.oauth_client = Some(oauth_client);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Fix OAuth2 client to use `client_secret_post` instead of `client_secret_basic`
- Aligns with Authelia OIDC configuration that expects POST method for client authentication
- Add debugging log to show configured authentication method
- Resolves "invalid_client" error during token exchange

## Test plan
- [x] All tests pass
- [x] Pre-commit hooks pass
- [ ] Test OAuth flow with deployed server

🤖 Generated with [Claude Code](https://claude.ai/code)