### PR TITLE
Fix Claude Code OAuth discovery by supporting POST requests

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -128,8 +128,11 @@ pub async fn handle_request(
     }
 
     // Handle OAuth well-known endpoints (public, no authentication required)
+    // Support GET, HEAD, and POST methods (some clients may use POST for discovery)
     if (req.uri().path() == OAUTH_WELL_KNOWN_PATH || req.uri().path() == OIDC_WELL_KNOWN_PATH)
-        && (req.method() == Method::GET || req.method() == Method::HEAD)
+        && (req.method() == Method::GET
+            || req.method() == Method::HEAD
+            || req.method() == Method::POST)
     {
         return handle_oauth_metadata(auth_service, req.method()).await;
     }

--- a/tests/end_to_end_oauth_test.rs
+++ b/tests/end_to_end_oauth_test.rs
@@ -520,8 +520,8 @@ async fn test_claude_code_discovery_scenario() {
         .await
         .expect("Failed to make POST request");
 
-    // Should return 401 because it falls through to main handler which requires auth
-    assert_eq!(post_response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    // Should return 200 because auth service is configured and can provide OAuth metadata
+    assert_eq!(post_response.status(), reqwest::StatusCode::OK);
 
     println!("✅ Claude Code discovery scenario test passed - HTTP 405 error fixed!");
 }


### PR DESCRIPTION
## Summary

Claude Code was getting **HTTP 405 errors** when trying to perform OAuth discovery. Analysis revealed that our OAuth well-known endpoints only supported GET and HEAD methods, but Claude Code may be making POST requests for discovery.

## Root Cause

The error "HTTP 405 trying to load well-known OAuth metadata" was occurring because:

1. Claude Code tries to access OAuth well-known endpoints
2. Our server only handled GET/HEAD requests on these endpoints  
3. If Claude Code sent POST requests, they fell through to the main handler
4. Main handler requires authentication and returns 405 for non-POST to non-MCP endpoints

## Solution

Added POST method support to both OAuth well-known endpoints:
- `/.well-known/oauth-authorization-server`
- `/.well-known/openid-configuration`

## Changes

- Updated endpoint handler to accept GET, HEAD, and POST methods
- Updated integration test to expect correct response when auth is configured
- All existing functionality remains unchanged

## Testing

✅ All unit tests pass  
✅ Integration tests verify POST requests work correctly  
✅ Manual testing confirmed endpoints work with all three methods

This should resolve the "HTTP 405 trying to load well-known OAuth metadata" error that Claude Code was experiencing.

🤖 Generated with [Claude Code](https://claude.ai/code)