### PR TITLE
Extend MCP token lifetime to 30 days

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -720,7 +720,7 @@ async fn handle_auth_request(
                     let response_data = serde_json::json!({
                         "access_token": access_token.secret(),
                         "token_type": "Bearer",
-                        "expires_in": 3600
+                        "expires_in": 2592000  // 30 days in seconds
                     });
                     Ok(Response::builder()
                         .status(StatusCode::OK)
@@ -795,7 +795,7 @@ async fn handle_auth_request(
                     let response_data = serde_json::json!({
                         "access_token": access_token.secret(),
                         "token_type": "Bearer",
-                        "expires_in": 3600
+                        "expires_in": 2592000  // 30 days in seconds
                     });
                     Ok(Response::builder()
                         .status(StatusCode::OK)


### PR DESCRIPTION
## Summary
- Update token expiration from 1 hour to 30 days
- Change hardcoded `expires_in` from 3600 to 2592000 seconds
- Update both token exchange and refresh token endpoints

## Background
This change supports longer MCP sessions by extending access token validity from 1 hour to 30 days. The corresponding Authelia configuration has been updated to issue 30-day access tokens.

## Changes
- `src/http_server.rs`: Update `expires_in` values in both token endpoints
- Matches new Authelia `access_token: 30d` configuration

## Test Plan
- [x] Code compiles and passes tests
- [ ] Test token exchange returns 30-day expiration
- [ ] Verify tokens actually last 30 days in practice

🤖 Generated with [Claude Code](https://claude.ai/code)