### PR TITLE
Fix: Handle prefixed MCP tool names

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -302,7 +302,14 @@ impl Service<RoleServer> for GoldentoothService {
                     let tool_name = &tool_request.params.name;
                     let arguments = &tool_request.params.arguments;
 
-                    match tool_name.as_ref() {
+                    // Handle prefixed tool names by extracting the last component after '__'
+                    let effective_tool_name = if tool_name.contains("__") {
+                        tool_name.split("__").last().unwrap_or(tool_name.as_ref())
+                    } else {
+                        tool_name.as_ref()
+                    };
+
+                    match effective_tool_name {
                         "cluster_ping" => match self.handle_cluster_ping().await {
                             Ok(result) => {
                                 let content = rmcp::model::Content::text(
@@ -516,7 +523,7 @@ impl Service<RoleServer> for GoldentoothService {
                         _ => {
                             Err(ErrorData {
                                 code: ErrorCode(-32601), // Method not found
-                                message: format!("Unknown tool: {}", tool_name).into(),
+                                message: format!("Unknown tool: {}", effective_tool_name).into(),
                                 data: None,
                             })
                         }


### PR DESCRIPTION
## Summary
- Fixed MCP error -32601 (Method not found) when clients send prefixed tool names
- Server now handles both `cluster_ping` and `mcp__goldentooth_mcp__cluster_ping` formats

## Problem
MCP clients may prefix tool names for disambiguation between servers (e.g., `mcp__goldentooth_mcp__cluster_ping`), but our server was only matching exact tool names like `cluster_ping`. This caused "Method not found" errors.

## Solution
Extract the base tool name by splitting on `__` and taking the last component. This allows the server to handle both prefixed and unprefixed tool names gracefully.

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds with no warnings
- [ ] Manual testing with MCP Inspector confirms tools work with prefixed names
- [ ] Claude Code can now use the Goldentooth MCP tools

🤖 Generated with [Claude Code](https://claude.ai/code)