### PR TITLE
Replace goldentooth CLI dependency with direct ICMP ping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
 urlencoding = "2.1"
 async-trait = "0.1"
+ping = "0.5"
+lazy_static = "1.4"
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
## Summary
This PR removes the dependency on the external `goldentooth` CLI command for the `cluster_ping` tool by implementing direct ICMP ping functionality in Rust.

## Changes Made
- ✅ **Direct ICMP ping**: Added `ping` crate dependency for ICMP connectivity testing
- ✅ **Node IP mapping**: Created static HashMap with all 13 cluster nodes and their IP addresses based on Ansible inventory
- ✅ **TCP fallback**: Implemented TCP connect to SSH port 22 if ICMP fails due to permissions
- ✅ **Enhanced error handling**: Added `NetworkError` variant to `ClusterOperationError`
- ✅ **Timeout configuration**: 2-second timeout for both ICMP and TCP tests
- ✅ **Independence**: MCP server no longer requires goldentooth CLI to be installed

## Technical Details
- **Dependencies**: Added `ping = "0.5"` and `lazy_static = "1.4"`
- **IP Mapping**: All nodes from `allyrion` (10.4.0.10) to `velaryon` (10.4.0.30)
- **Fallback Strategy**: ICMP → TCP:22 → Report offline
- **Performance**: Parallel pings with 2s timeout per node

## Testing
- ✅ All existing tests pass
- ✅ Code compiles without warnings
- ✅ Pre-commit hooks (rustfmt, clippy) pass
- ✅ No breaking changes to public API

## Benefits
1. **Reduced dependencies**: No need for goldentooth CLI in MCP server environment
2. **Better reliability**: Direct network calls instead of subprocess execution
3. **Improved error handling**: Specific network error types
4. **Faster execution**: No subprocess overhead

## Deployment Impact
Once merged and released, this will resolve the "No such file or directory" error currently occurring with the `mcp__goldentooth_mcp__cluster_ping` tool.

🤖 Generated with [Claude Code](https://claude.ai/code)