### PR TITLE
Implement environment-independent MCP tools for service status and resource usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The server automatically creates new releases with incremented versions on every
 
 The server provides the following tools for cluster management:
 
-- **`cluster_ping`** - Ping all cluster nodes to check connectivity and basic status
-- **`cluster_status`** - Get detailed status information for specific nodes or all nodes
-- **`service_status`** - Check the status of systemd services (consul, nomad, vault, etc.) across nodes
-- **`resource_usage`** - Get memory and disk usage information for cluster nodes
+- **`cluster_ping`** - Ping all cluster nodes to check connectivity using ICMP (with TCP fallback)
+- **`cluster_status`** - Get detailed status information including uptime and load averages via node_exporter metrics
+- **`service_status`** - Check systemd service status across nodes via node_exporter systemd metrics
+- **`resource_usage`** - Get memory and disk usage information via node_exporter resource metrics
 - **`cluster_info`** - Get comprehensive cluster information including node status and service membership
 
 All tools support both prefixed (`mcp__goldentooth_mcp__cluster_ping`) and unprefixed (`cluster_ping`) naming conventions for compatibility with different MCP clients.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,4 +1,3 @@
-use crate::command::CommandExecutor;
 use async_trait::async_trait;
 use lazy_static::lazy_static;
 use ping::ping;
@@ -102,14 +101,13 @@ pub trait ClusterOperations: Send + Sync {
     ) -> Result<HashMap<String, ResourceUsage>, ClusterOperationError>;
 }
 
-/// Default implementation using CommandExecutor
-pub struct DefaultClusterOperations<E: CommandExecutor> {
-    executor: E,
-}
+/// Default implementation of cluster operations
+#[derive(Default)]
+pub struct DefaultClusterOperations;
 
-impl<E: CommandExecutor> DefaultClusterOperations<E> {
-    pub fn new(executor: E) -> Self {
-        Self { executor }
+impl DefaultClusterOperations {
+    pub fn new() -> Self {
+        Self
     }
 
     /// TCP "ping" - attempt to connect to a specific port to test connectivity
@@ -159,7 +157,7 @@ impl<E: CommandExecutor> DefaultClusterOperations<E> {
 }
 
 #[async_trait]
-impl<E: CommandExecutor + Send + Sync> ClusterOperations for DefaultClusterOperations<E> {
+impl ClusterOperations for DefaultClusterOperations {
     async fn ping_all_nodes(&self) -> Result<Vec<NodeStatus>, ClusterOperationError> {
         use futures::future::join_all;
 
@@ -225,108 +223,124 @@ impl<E: CommandExecutor + Send + Sync> ClusterOperations for DefaultClusterOpera
         service: &str,
         node: Option<&str>,
     ) -> Result<Vec<ServiceStatus>, ClusterOperationError> {
-        let node_arg = node.unwrap_or("all");
-        let command = format!("systemctl status {}", service);
+        use futures::future::join_all;
 
-        let output = self
-            .executor
-            .execute("goldentooth", &["command", node_arg, &command])
-            .await
-            .map_err(ClusterOperationError::CommandFailed)?;
+        let nodes_to_check: Vec<&str> = if let Some(specific_node) = node {
+            vec![specific_node]
+        } else {
+            NODE_IPS.keys().copied().collect()
+        };
 
-        let mut statuses = Vec::new();
-        let mut current_node = String::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|e| {
+                ClusterOperationError::NetworkError(format!("HTTP client error: {}", e))
+            })?;
 
-        for line in output.lines() {
-            // Node header format: "=== nodename ==="
-            if line.starts_with("=== ") && line.ends_with(" ===") {
-                current_node = line
-                    .trim_start_matches("=== ")
-                    .trim_end_matches(" ===")
-                    .to_string();
-            } else if line.contains("Active: ") && !current_node.is_empty() {
-                let is_active = line.contains("active (running)");
+        // Query all specified nodes in parallel
+        let query_futures: Vec<_> = nodes_to_check
+            .into_iter()
+            .map(|node_name| {
+                let client = client.clone();
+                let service_name = service.to_string();
+                async move {
+                    let ip_str = NODE_IPS.get(node_name).copied().unwrap_or("127.0.0.1");
+                    let url = format!("http://{}:9100/metrics", ip_str);
 
-                statuses.push(ServiceStatus {
-                    name: service.to_string(),
-                    node: current_node.clone(),
-                    is_active,
-                    is_enabled: true, // Would need to parse more output for this
-                    uptime: None,     // Would need to parse the "since" part
-                });
-            }
-        }
+                    match client.get(&url).send().await {
+                        Ok(response) if response.status().is_success() => {
+                            match response.text().await {
+                                Ok(metrics_text) => self.parse_service_status_from_metrics(
+                                    node_name,
+                                    &service_name,
+                                    &metrics_text,
+                                ),
+                                Err(_) => ServiceStatus {
+                                    name: service_name,
+                                    node: node_name.to_string(),
+                                    is_active: false,
+                                    is_enabled: false,
+                                    uptime: None,
+                                },
+                            }
+                        }
+                        _ => ServiceStatus {
+                            name: service_name,
+                            node: node_name.to_string(),
+                            is_active: false,
+                            is_enabled: false,
+                            uptime: None,
+                        },
+                    }
+                }
+            })
+            .collect();
 
-        Ok(statuses)
+        let results = join_all(query_futures).await;
+        Ok(results)
     }
 
     async fn get_resource_usage(
         &self,
         node: Option<&str>,
     ) -> Result<HashMap<String, ResourceUsage>, ClusterOperationError> {
-        let node_arg = node.unwrap_or("all");
+        use futures::future::join_all;
 
-        let output = self
-            .executor
-            .execute("goldentooth", &["command", node_arg, "free -h && df -h"])
-            .await
-            .map_err(ClusterOperationError::CommandFailed)?;
+        let nodes_to_check: Vec<&str> = if let Some(specific_node) = node {
+            vec![specific_node]
+        } else {
+            NODE_IPS.keys().copied().collect()
+        };
 
-        let mut result = HashMap::new();
-        let current_node = node.unwrap_or("unknown").to_string();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|e| {
+                ClusterOperationError::NetworkError(format!("HTTP client error: {}", e))
+            })?;
 
-        // Parse memory usage from free -h output
-        let mut memory_usage = None;
-        let mut disk_usage = Vec::new();
-        let mut in_df_section = false;
+        // Query all specified nodes in parallel
+        let query_futures: Vec<_> = nodes_to_check
+            .into_iter()
+            .map(|node_name| {
+                let client = client.clone();
+                async move {
+                    let ip_str = NODE_IPS.get(node_name).copied().unwrap_or("127.0.0.1");
+                    let url = format!("http://{}:9100/metrics", ip_str);
 
-        for line in output.lines() {
-            if line.starts_with("Mem:") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 3 {
-                    memory_usage = Some(MemoryUsage {
-                        total_mb: parse_size_to_mb(parts[1]),
-                        used_mb: parse_size_to_mb(parts[2]),
-                        free_mb: parse_size_to_mb(parts[3]),
-                        percent_used: 0.0, // Calculate below
-                    });
+                    match client.get(&url).send().await {
+                        Ok(response) if response.status().is_success() => {
+                            match response.text().await {
+                                Ok(metrics_text) => {
+                                    match self.parse_resource_usage_from_metrics(&metrics_text) {
+                                        Ok(resource_usage) => {
+                                            Some((node_name.to_string(), resource_usage))
+                                        }
+                                        Err(_) => None,
+                                    }
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        _ => None,
+                    }
                 }
-            } else if line.contains("Filesystem") && line.contains("Size") {
-                in_df_section = true;
-            } else if in_df_section && line.starts_with("/dev/") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 6 {
-                    disk_usage.push(DiskUsage {
-                        filesystem: parts[0].to_string(),
-                        total_gb: parse_size_to_gb(parts[1]),
-                        used_gb: parse_size_to_gb(parts[2]),
-                        available_gb: parse_size_to_gb(parts[3]),
-                        percent_used: parts[4].trim_end_matches('%').parse().unwrap_or(0.0),
-                        mount_point: parts[5].to_string(),
-                    });
-                }
-            }
+            })
+            .collect();
+
+        let results = join_all(query_futures).await;
+        let mut resource_map = HashMap::new();
+
+        for result in results.into_iter().flatten() {
+            resource_map.insert(result.0, result.1);
         }
 
-        if let Some(mut mem) = memory_usage {
-            if mem.total_mb > 0 {
-                mem.percent_used = (mem.used_mb as f32 / mem.total_mb as f32) * 100.0;
-            }
-
-            result.insert(
-                current_node.clone(),
-                ResourceUsage {
-                    memory: mem,
-                    disk: disk_usage,
-                },
-            );
-        }
-
-        Ok(result)
+        Ok(resource_map)
     }
 }
 
-impl<E: CommandExecutor> DefaultClusterOperations<E> {
+impl DefaultClusterOperations {
     /// Parse node_exporter metrics to extract uptime and load averages
     /// Returns (uptime_string, load_average_tuple)
     fn parse_node_exporter_metrics(
@@ -393,38 +407,201 @@ impl<E: CommandExecutor> DefaultClusterOperations<E> {
 
         Ok((uptime, load_average))
     }
-}
 
-/// Parse size strings like "7.6Gi", "255M", "59G" to MB
-fn parse_size_to_mb(size_str: &str) -> u64 {
-    if let Some(num_str) = size_str.strip_suffix("Gi") {
-        (num_str.parse::<f32>().unwrap_or(0.0) * 1024.0) as u64
-    } else if let Some(num_str) = size_str.strip_suffix("G") {
-        (num_str.parse::<f32>().unwrap_or(0.0) * 1024.0) as u64
-    } else if let Some(num_str) = size_str.strip_suffix("Mi") {
-        num_str.parse().unwrap_or(0)
-    } else if let Some(num_str) = size_str.strip_suffix("M") {
-        num_str.parse().unwrap_or(0)
-    } else if let Some(num_str) = size_str.strip_suffix("Ki") {
-        num_str.parse::<u64>().unwrap_or(0) / 1024
-    } else if let Some(num_str) = size_str.strip_suffix("K") {
-        num_str.parse::<u64>().unwrap_or(0) / 1024
-    } else {
-        0
+    /// Parse systemd service status from node_exporter metrics
+    /// Looks for node_systemd_unit_state metrics to determine service status
+    fn parse_service_status_from_metrics(
+        &self,
+        node_name: &str,
+        service_name: &str,
+        metrics_text: &str,
+    ) -> ServiceStatus {
+        let mut is_active = false;
+        let mut is_enabled = false;
+        let mut start_time: Option<f64> = None;
+
+        // Look for systemd unit state metrics
+        // Format: node_systemd_unit_state{name="service.service",state="active",type="service"} 1
+        for line in metrics_text.lines() {
+            if line.starts_with('#') || line.trim().is_empty() {
+                continue;
+            }
+
+            // Check for service state (active/inactive)
+            if line.starts_with("node_systemd_unit_state{")
+                && line.contains(&format!("name=\"{}.service\"", service_name))
+                && line.contains("state=\"active\"")
+                && line.ends_with(" 1")
+            {
+                is_active = true;
+            }
+
+            // Check for service enabled state
+            if line.starts_with("node_systemd_unit_state{")
+                && line.contains(&format!("name=\"{}.service\"", service_name))
+                && line.contains("state=\"enabled\"")
+                && line.ends_with(" 1")
+            {
+                is_enabled = true;
+            }
+
+            // Look for service start time if available
+            // Format: node_systemd_system_running 1704067200
+            if line.starts_with(&format!(
+                "node_systemd_service_start_time_seconds{{name=\"{}.service\"}}",
+                service_name
+            )) {
+                if let Some(value_str) = line.split_whitespace().nth(1) {
+                    start_time = value_str.parse().ok();
+                }
+            }
+        }
+
+        // Calculate uptime if we have start time
+        let uptime = if let Some(start_timestamp) = start_time {
+            let current_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as f64;
+
+            let uptime_seconds = current_time - start_timestamp;
+            if uptime_seconds > 0.0 {
+                Some(format_uptime(uptime_seconds as u64))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        ServiceStatus {
+            name: service_name.to_string(),
+            node: node_name.to_string(),
+            is_active,
+            is_enabled,
+            uptime,
+        }
+    }
+
+    /// Parse memory and disk usage from node_exporter metrics
+    fn parse_resource_usage_from_metrics(
+        &self,
+        metrics_text: &str,
+    ) -> Result<ResourceUsage, ClusterOperationError> {
+        let mut memory_total: Option<u64> = None;
+        let mut memory_available: Option<u64> = None;
+        let mut filesystems: HashMap<String, (f32, f32, String)> = HashMap::new(); // (total_gb, avail_gb, mount)
+
+        for line in metrics_text.lines() {
+            if line.starts_with('#') || line.trim().is_empty() {
+                continue;
+            }
+
+            // Parse memory metrics (in bytes)
+            if line.starts_with("node_memory_MemTotal_bytes ") {
+                if let Some(value_str) = line.split_whitespace().nth(1) {
+                    if let Ok(bytes) = value_str.parse::<u64>() {
+                        memory_total = Some(bytes / 1_048_576); // Convert to MB
+                    }
+                }
+            } else if line.starts_with("node_memory_MemAvailable_bytes ") {
+                if let Some(value_str) = line.split_whitespace().nth(1) {
+                    if let Ok(bytes) = value_str.parse::<u64>() {
+                        memory_available = Some(bytes / 1_048_576); // Convert to MB
+                    }
+                }
+            }
+            // Parse filesystem metrics (in bytes)
+            else if line.starts_with("node_filesystem_size_bytes{") {
+                if let Some(device) = extract_label_value(line, "device") {
+                    if let Some(mountpoint) = extract_label_value(line, "mountpoint") {
+                        if let Some(value_str) = line.split_whitespace().last() {
+                            if let Ok(bytes) = value_str.parse::<u64>() {
+                                let total_gb = bytes as f32 / 1_073_741_824.0; // Convert to GB
+                                filesystems
+                                    .entry(device)
+                                    .or_insert((0.0, 0.0, mountpoint))
+                                    .0 = total_gb;
+                            }
+                        }
+                    }
+                }
+            } else if line.starts_with("node_filesystem_avail_bytes{") {
+                if let Some(device) = extract_label_value(line, "device") {
+                    if let Some(mountpoint) = extract_label_value(line, "mountpoint") {
+                        if let Some(value_str) = line.split_whitespace().last() {
+                            if let Ok(bytes) = value_str.parse::<u64>() {
+                                let avail_gb = bytes as f32 / 1_073_741_824.0; // Convert to GB
+                                filesystems
+                                    .entry(device.clone())
+                                    .or_insert((0.0, 0.0, mountpoint))
+                                    .1 = avail_gb;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Build memory usage
+        let memory = if let (Some(total), Some(available)) = (memory_total, memory_available) {
+            let used = total.saturating_sub(available);
+            let percent_used = if total > 0 {
+                (used as f32 / total as f32) * 100.0
+            } else {
+                0.0
+            };
+
+            MemoryUsage {
+                total_mb: total,
+                used_mb: used,
+                free_mb: available,
+                percent_used,
+            }
+        } else {
+            return Err(ClusterOperationError::ParseError(
+                "Could not parse memory metrics".to_string(),
+            ));
+        };
+
+        // Build disk usage from filesystems
+        let disk: Vec<DiskUsage> = filesystems
+            .into_iter()
+            .filter(|(device, _)| device.starts_with("/dev/")) // Only real devices
+            .map(|(filesystem, (total_gb, avail_gb, mount_point))| {
+                let used_gb = total_gb - avail_gb;
+                let percent_used = if total_gb > 0.0 {
+                    (used_gb / total_gb) * 100.0
+                } else {
+                    0.0
+                };
+
+                DiskUsage {
+                    filesystem,
+                    total_gb,
+                    used_gb,
+                    available_gb: avail_gb,
+                    percent_used,
+                    mount_point,
+                }
+            })
+            .collect();
+
+        Ok(ResourceUsage { memory, disk })
     }
 }
 
-/// Parse size strings to GB
-fn parse_size_to_gb(size_str: &str) -> f32 {
-    if let Some(num_str) = size_str.strip_suffix("G") {
-        num_str.parse().unwrap_or(0.0)
-    } else if let Some(num_str) = size_str.strip_suffix("M") {
-        num_str.parse::<f32>().unwrap_or(0.0) / 1024.0
-    } else if let Some(num_str) = size_str.strip_suffix("T") {
-        num_str.parse::<f32>().unwrap_or(0.0) * 1024.0
-    } else {
-        0.0
+/// Extract label value from Prometheus metrics line
+/// Example: extract_label_value('node_filesystem_size_bytes{device="/dev/sda1",mountpoint="/"} 123', "device") -> Some("/dev/sda1")
+fn extract_label_value(line: &str, label: &str) -> Option<String> {
+    let pattern = format!("{}=\"", label);
+    if let Some(start_pos) = line.find(&pattern) {
+        let value_start = start_pos + pattern.len();
+        if let Some(end_pos) = line[value_start..].find('"') {
+            return Some(line[value_start..value_start + end_pos].to_string());
+        }
     }
+    None
 }
 
 /// Format uptime seconds into human-readable string like "5 days, 3:15"
@@ -546,24 +723,8 @@ impl ClusterOperations for MockClusterOperations {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command::MockCommandExecutor;
     use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
-
-    #[test]
-    fn test_parse_size_to_mb() {
-        assert_eq!(parse_size_to_mb("7.6Gi"), 7782);
-        assert_eq!(parse_size_to_mb("2.1Gi"), 2150);
-        assert_eq!(parse_size_to_mb("255M"), 255);
-        assert_eq!(parse_size_to_mb("1024Ki"), 1);
-    }
-
-    #[test]
-    fn test_parse_size_to_gb() {
-        assert_eq!(parse_size_to_gb("59G"), 59.0);
-        assert_eq!(parse_size_to_gb("255M"), 0.249_023_44);
-        assert_eq!(parse_size_to_gb("2T"), 2048.0);
-    }
 
     #[test]
     fn test_node_ips_static_map() {
@@ -584,8 +745,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tcp_ping_localhost() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         // Test TCP "ping" to localhost on a port that should be closed
         let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
@@ -598,8 +758,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping_single_node_invalid_ip() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         let result = cluster_ops
             .ping_single_node("test".to_string(), "invalid.ip".to_string())
@@ -616,8 +775,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping_single_node_valid_format() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         // Use localhost IP - this may or may not succeed depending on ICMP permissions
         // but should at least not error on IP parsing
@@ -647,8 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping_all_nodes_structure() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         // This test verifies the structure and parallel execution
         // Individual pings may fail, but the overall structure should work
@@ -679,8 +836,7 @@ mod tests {
 
     #[test]
     fn test_parse_node_exporter_metrics() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         // Mock metrics text with boot time and load averages
         let metrics_text = r#"
@@ -716,8 +872,7 @@ node_memory_MemTotal_bytes 8589934592
 
     #[test]
     fn test_parse_node_exporter_metrics_missing_data() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         // Metrics with missing load data
         let metrics_text = r#"
@@ -738,8 +893,7 @@ node_load1 0.15
 
     #[test]
     fn test_parse_node_exporter_metrics_empty() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         let result = cluster_ops.parse_node_exporter_metrics("");
         assert!(result.is_ok());
@@ -751,8 +905,7 @@ node_load1 0.15
 
     #[test]
     fn test_parse_node_exporter_metrics_comments_only() {
-        let executor = MockCommandExecutor::new();
-        let cluster_ops = DefaultClusterOperations::new(executor);
+        let cluster_ops = DefaultClusterOperations::new();
 
         let metrics_text = r#"
 # HELP node_boot_time_seconds Node boot time, in unixtime.

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,5 @@
 use crate::auth::{AuthConfig, AuthError, AuthService};
 use crate::cluster::{ClusterOperations, DefaultClusterOperations};
-use crate::command::SystemCommandExecutor;
 use rmcp::{
     RoleServer, Service,
     model::{
@@ -66,8 +65,7 @@ impl GoldentoothService {
             None
         };
 
-        let executor = SystemCommandExecutor::new();
-        let cluster_ops = Arc::new(DefaultClusterOperations::new(executor));
+        let cluster_ops = Arc::new(DefaultClusterOperations::new());
 
         GoldentoothService {
             auth_service,
@@ -94,8 +92,7 @@ impl GoldentoothService {
         let mut auth_service = AuthService::new(auth_config);
         auth_service.initialize().await?;
 
-        let executor = SystemCommandExecutor::new();
-        let cluster_ops = Arc::new(DefaultClusterOperations::new(executor));
+        let cluster_ops = Arc::new(DefaultClusterOperations::new());
 
         let service = GoldentoothService {
             auth_service: Some(auth_service.clone()),


### PR DESCRIPTION
## Summary
Implements environment-independent service_status and resource_usage MCP tools, removing dependency on the goldentooth CLI. All 5 MCP tools now use direct network-based approaches via node_exporter.

## Key Changes

### Environment-Independent Implementation
- service_status: Now queries node_exporter systemd metrics instead of CLI commands
- resource_usage: Now queries node_exporter memory/filesystem metrics instead of CLI commands
- All tools consistently use HTTP requests to node_exporter:9100 across 13 cluster nodes

### Technical Improvements
**Service Status**:
- Parse node_systemd_unit_state metrics for active/enabled status
- Calculate service uptime from start timestamps
- Support both single-node and all-nodes queries with parallel execution

**Resource Usage**:
- Parse node_memory_* and node_filesystem_* metrics
- Provide comprehensive memory (MB) and disk (GB) statistics  
- Filter real devices and calculate usage percentages

### Code Quality
- Remove unused CommandExecutor dependency from DefaultClusterOperations
- Clean up dead code and unused parsing functions
- All 58 tests passing with no compilation warnings

## Impact
This completes the MCP server evolution to a fully environment-independent tool that can run anywhere with network access to the cluster.

Generated with Claude Code