### PR TITLE
Add HTTP screenshot serving capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,11 @@ jobs:
         toolchain: 1.86.0
         components: clippy, rustfmt
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-test-${{ hashFiles('**/Cargo.lock') }}
+        # Cache key depends on Cargo files and current job
+        key: test-${{ runner.os }}
 
     - name: Check formatting
       run: cargo fmt --all -- --check
@@ -90,11 +78,10 @@ jobs:
     - name: Install cargo-llvm-cov
       run: cargo install cargo-llvm-cov
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: coverage-${{ runner.os }}
 
     - name: Generate coverage report
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
@@ -141,17 +128,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-aarch64-linux-gnu
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: target
-        key: ${{ runner.os }}-${{ matrix.target }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+        key: build-${{ matrix.target }}
 
     - name: Build for target
       run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Optional: Customize review based on file types
           # direct_prompt: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-aarch64-linux-gnu
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v4
-      with:
-        path: target
-        key: ${{ runner.os }}-${{ matrix.target }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+        key: release-${{ matrix.target }}
 
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ chrono = { version = "0.4", features = ["serde"] }
 headless_chrome = "1.0"
 image = "0.25"
 tempfile = "3.8"
+bytes = "1.9"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/examples/grafana_screenshot.rs
+++ b/examples/grafana_screenshot.rs
@@ -42,6 +42,8 @@ async fn main() {
         ),
         wait_timeout_ms: Some(15000),
         authenticate: Some(auth_config),
+        save_to_file: Some(true),
+        file_directory: Some("/tmp/screenshots".to_string()),
     };
 
     match screenshot_service.capture_screenshot(request).await {

--- a/examples/grafana_screenshot.rs
+++ b/examples/grafana_screenshot.rs
@@ -44,6 +44,8 @@ async fn main() {
         authenticate: Some(auth_config),
         save_to_file: Some(true),
         file_directory: Some("/tmp/screenshots".to_string()),
+        http_serve: Some(true),
+        http_base_url: Some("http://localhost:8081".to_string()),
     };
 
     match screenshot_service.capture_screenshot(request).await {

--- a/examples/test_screenshot.rs
+++ b/examples/test_screenshot.rs
@@ -14,6 +14,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         wait_for_selector: None,
         wait_timeout_ms: Some(5000),
         authenticate: None,
+        save_to_file: Some(true),
+        file_directory: Some("/tmp/screenshots".to_string()),
     };
 
     println!("📸 Testing basic screenshot capture...");
@@ -39,6 +41,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "   - First 50 chars: {}",
                     &image_data[..50.min(image_data.len())]
                 );
+            }
+
+            if let Some(file_path) = &response.file_path {
+                println!("   - Saved to file: {file_path}");
+                if std::path::Path::new(file_path).exists() {
+                    println!("   - ✅ File verified on disk");
+                } else {
+                    println!("   - ❌ File not found on disk");
+                }
             }
         }
         Err(e) => {

--- a/examples/test_screenshot.rs
+++ b/examples/test_screenshot.rs
@@ -16,6 +16,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         authenticate: None,
         save_to_file: Some(true),
         file_directory: Some("/tmp/screenshots".to_string()),
+        http_serve: Some(true),
+        http_base_url: Some("http://localhost:8081".to_string()),
     };
 
     println!("📸 Testing basic screenshot capture...");
@@ -50,6 +52,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     println!("   - ❌ File not found on disk");
                 }
+            }
+
+            if let Some(screenshot_url) = &response.screenshot_url {
+                println!("   - Available via HTTP: {screenshot_url}");
             }
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Failed to initialize screenshot HTTP server: {e}");
         eprintln!("Screenshots will still work but won't be served via HTTP");
     } else {
-        println!("Screenshot HTTP server initialized on port 8081");
+        let port = std::env::var("SCREENSHOT_HTTP_PORT").unwrap_or_else(|_| "8081".to_string());
+        println!("Screenshot HTTP server initialized on port {port}");
     }
 
     // Check for HTTP mode via environment variable or command line arg

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         (GoldentoothService::new(), None)
     };
 
+    // Initialize screenshot HTTP server
+    if let Err(e) = service.initialize_http_server().await {
+        eprintln!("Failed to initialize screenshot HTTP server: {e}");
+        eprintln!("Screenshots will still work but won't be served via HTTP");
+    } else {
+        println!("Screenshot HTTP server initialized on port 8081");
+    }
+
     // Check for HTTP mode via environment variable or command line arg
     if env::var("MCP_HTTP_MODE").is_ok() || env::args().any(|arg| arg == "--http") {
         // HTTP server mode

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -13,6 +13,7 @@ use tokio::net::TcpListener;
 
 use base64::Engine;
 use headless_chrome::{Browser, LaunchOptions, Tab};
+use log::error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -158,12 +159,12 @@ impl ScreenshotService {
                                 if let Err(e) =
                                     http1::Builder::new().serve_connection(io, service).await
                                 {
-                                    eprintln!("Screenshot HTTP connection error: {e}");
+                                    error!("Screenshot HTTP connection error: {e}");
                                 }
                             });
                         }
                         Err(e) => {
-                            eprintln!("Screenshot HTTP server accept error: {e}");
+                            error!("Screenshot HTTP server accept error: {e}");
                         }
                     }
                 }
@@ -745,8 +746,8 @@ mod tests {
         let function_url = crate::service::GoldentoothService::get_screenshot_base_url();
         assert_eq!(function_url, "http://velaryon.nodes.goldentooth.net:8081");
 
-        // Restore original values to avoid affecting other tests
         unsafe {
+            // Restore original values to avoid affecting other tests
             if let Some(port) = original_port {
                 env::set_var("SCREENSHOT_HTTP_PORT", port);
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1405,7 +1405,7 @@ impl Service<RoleServer> for GoldentoothService {
                                 .unwrap_or(true); // Default to HTTP serving
 
                             let http_base_url = if http_serve {
-                                Some("http://velaryon.nodes.goldentooth.net:8081".to_string())
+                                Some(Self::get_screenshot_base_url())
                             } else {
                                 None
                             };

--- a/src/service.rs
+++ b/src/service.rs
@@ -51,7 +51,7 @@ impl Default for GoldentoothService {
 }
 
 impl GoldentoothService {
-    fn get_screenshot_base_url() -> String {
+    pub fn get_screenshot_base_url() -> String {
         let host = std::env::var("SCREENSHOT_HTTP_HOST")
             .unwrap_or_else(|_| "velaryon.nodes.goldentooth.net".to_string());
         let port = std::env::var("SCREENSHOT_HTTP_PORT").unwrap_or_else(|_| "8081".to_string());


### PR DESCRIPTION
## Summary
- Added HTTP server functionality for serving screenshot files instead of returning large base64 responses
- Configured HTTP server on port 8081 to serve static screenshot files
- Updated ScreenshotResponse struct with file_path and screenshot_url fields
- Enhanced MCP service initialization to start HTTP server automatically

## Test plan
- [ ] Build and run the MCP server locally
- [ ] Test screenshot capture with HTTP serving enabled
- [ ] Verify HTTP server serves files correctly on port 8081
- [ ] Confirm screenshots are accessible via returned URLs
- [ ] Test with Grafana dashboard authentication flow

🤖 Generated with [Claude Code](https://claude.ai/code)