### PR TITLE
Update MCP protocol version to 2025-06-18

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -268,9 +268,9 @@ fn validate_initialize_params(params: &Option<Value>) -> Result<(), String> {
         .ok_or("protocolVersion must be a string")?;
 
     // Validate supported protocol version
-    if version_str != "2024-11-05" {
+    if version_str != "2025-06-18" {
         return Err(format!(
-            "Unsupported protocol version '{version_str}', expected '2024-11-05'"
+            "Unsupported protocol version '{version_str}', expected '2025-06-18'"
         ));
     }
 

--- a/src/types/mcp_message.rs
+++ b/src/types/mcp_message.rs
@@ -204,7 +204,7 @@ impl McpResponse {
     pub fn initialize_response(id: MessageId, capabilities: Value, server_info: Value) -> Self {
         Self::new(
             serde_json::json!({
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": "2025-06-18",
                 "capabilities": capabilities,
                 "serverInfo": server_info
             }),

--- a/src/types/protocol_state.rs
+++ b/src/types/protocol_state.rs
@@ -460,7 +460,7 @@ mod tests {
             name: "test-client".to_string(),
             version: "1.0.0".to_string(),
         };
-        let state = state.complete_initialization("2024-11-05".to_string(), client_info);
+        let state = state.complete_initialization("2025-06-18".to_string(), client_info);
         assert!(state.can_accept_requests());
         assert!(!state.is_method_allowed("initialize"));
         assert!(state.is_method_allowed("ping"));
@@ -490,7 +490,7 @@ mod tests {
             name: "test-client".to_string(),
             version: "1.0.0".to_string(),
         };
-        let state = state.complete_initialization("2024-11-05".to_string(), client_info);
+        let state = state.complete_initialization("2025-06-18".to_string(), client_info);
 
         // Now ping should be allowed
         assert!(ProtocolCompliance::validate_request(&state, "ping").is_ok());

--- a/tests/common/test_helpers.rs
+++ b/tests/common/test_helpers.rs
@@ -109,7 +109,7 @@ impl McpRequestBuilders {
         JsonRpcRequestBuilder::new("initialize")
             .with_id(id)
             .with_params(json!({
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": "2025-06-18",
                 "capabilities": {},
                 "clientInfo": {
                     "name": "test-client",
@@ -228,7 +228,7 @@ impl ResponseAssertions {
         Self::assert_success_response(response, expected_id);
         assert!(response["result"]["capabilities"].is_object());
         assert!(response["result"]["serverInfo"].is_object());
-        assert_eq!(response["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(response["result"]["protocolVersion"], "2025-06-18");
     }
 }
 

--- a/tests/compile_time_safety.rs
+++ b/tests/compile_time_safety.rs
@@ -76,7 +76,7 @@ fn test_protocol_state_transitions_compile_time() {
         name: "test-client".to_string(),
         version: "1.0.0".to_string(),
     };
-    let state = state.complete_initialization("2024-11-05".to_string(), client_info);
+    let state = state.complete_initialization("2025-06-18".to_string(), client_info);
 
     // Now ping is allowed
     assert!(ProtocolCompliance::validate_request(&state, "ping").is_ok());

--- a/tests/http_transport.rs
+++ b/tests/http_transport.rs
@@ -314,7 +314,7 @@ async fn test_request_response_format_validation() {
     assert_eq!(initialize_request["method"], "initialize");
     assert_eq!(
         initialize_request["params"]["protocolVersion"],
-        "2024-11-05"
+        "2025-06-18"
     );
     assert!(initialize_request["params"]["capabilities"].is_object());
     assert!(initialize_request["params"]["clientInfo"].is_object());
@@ -333,7 +333,7 @@ async fn test_expected_response_format() {
                 "name": "goldentooth-mcp",
                 "version": "0.0.23"
             },
-            "protocolVersion": "2024-11-05"
+            "protocolVersion": "2025-06-18"
         }
     });
 

--- a/tests/input_validation.rs
+++ b/tests/input_validation.rs
@@ -58,7 +58,7 @@ async fn test_initialize_request_validation() {
         "method": "initialize",
         "id": 3,
         "params": {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {"name": "test", "version": "1.0"}
         }

--- a/tests/logging_validation.rs
+++ b/tests/logging_validation.rs
@@ -176,7 +176,7 @@ async fn integration_test_stdio_separation() {
         Ok(mut child) => {
             // Send MCP request
             if let Some(stdin) = child.stdin.as_mut() {
-                let request = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+                let request = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
                 let _ = stdin.write_all(request.as_bytes()).await;
                 let _ = stdin.write_all(b"\n").await;
             }

--- a/tests/protocol_compliance.rs
+++ b/tests/protocol_compliance.rs
@@ -9,7 +9,7 @@ async fn test_initialize_handshake() {
         "method": "initialize",
         "id": 1,
         "params": {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {
                 "name": "test-client",

--- a/tests/protocol_edge_cases.rs
+++ b/tests/protocol_edge_cases.rs
@@ -55,7 +55,7 @@ async fn test_all_mcp_methods_coverage() {
     let init_request = McpRequest::new(
         McpMethod::Initialize,
         Some(json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {"name": "test", "version": "1.0"}
         })),

--- a/tests/subprocess_execution.rs
+++ b/tests/subprocess_execution.rs
@@ -114,7 +114,7 @@ async fn test_stdout_only_contains_mcp_messages() {
             let mut stdout = BufReader::new(child.stdout.as_mut().unwrap());
 
             // Send MCP initialize request
-            let init_request = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+            let init_request = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
 
             if let Err(e) = stdin.write_all(init_request.as_bytes()).await {
                 panic!("Should be able to write to stdin: {e}");


### PR DESCRIPTION
## Summary
- Updates MCP protocol version from 2024-11-05 to 2025-06-18
- Aligns server with latest MCP specification and Python agent compatibility
- Updates validation logic, response generation, and all test cases

## Test plan
- [x] All existing tests pass with new protocol version
- [x] Pre-commit hooks pass (rustfmt, clippy, cargo check, cargo test)
- [x] Protocol validation correctly accepts 2025-06-18 and rejects older versions

🤖 Generated with [Claude Code](https://claude.ai/code)