### PR TITLE
Fix release workflow by removing non-existent systemd service file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,6 @@ jobs:
         else
           cp target/${{ matrix.target }}/release/goldentooth-mcp artifacts/${{ matrix.name }}
         fi
-        # Copy systemd service file only for x86_64 Linux target to avoid duplicates
-        if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
-          cp goldentooth-mcp.service artifacts/
-        fi
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
The release workflow was failing because it tried to copy a  file that doesn't exist in the repository.

**Error:** https://github.com/goldentooth/mcp-server/actions/runs/16853443632/job/47743064980

## Solution
Removes the unnecessary systemd service file copying step from the artifact preparation stage of the release workflow.

## Changes
- Remove systemd service file reference from 
- Clean up artifact preparation to only copy the binary executables

## Test Plan
- [x] YAML validation passes
- [x] No other workflow changes needed
- [x] Will test release workflow on next tag

This is a targeted fix that only removes the problematic step without affecting the cross-platform binary builds that were recently added.

🤖 Generated with [Claude Code](https://claude.ai/code)